### PR TITLE
[FIX] 画面回転を無効化

### DIFF
--- a/iOSEngineerCodeCheck/Info.plist
+++ b/iOSEngineerCodeCheck/Info.plist
@@ -50,15 +50,13 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## 概要
- 画面回転するとUIが崩れていたので，iPhoneについて画面回転を無効化し縦画面のみとした

## 関係するISSUE
- Resolve #32 

## レビューして欲しいポイント！ 
- 

## スクリーンショット(説明がわかりやすくなるスクリーンショットがあれば添付)
- 