### PR TITLE
[FEAT] SearchBarのテキスト情報を改善

### DIFF
--- a/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryTableViewController.swift
+++ b/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryTableViewController.swift
@@ -58,11 +58,6 @@ class SearchRepositoryTableViewController: UITableViewController {
 }
 
 extension SearchRepositoryTableViewController: UISearchBarDelegate {
-    func searchBarShouldBeginEditing(_ searchBar: UISearchBar) -> Bool {
-        // ↓こうすれば初期のテキストを消せる
-        searchBar.text = ""
-        return true
-    }
 
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
         guard let keyword = searchBar.text else { return }

--- a/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryTableViewController.swift
+++ b/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryTableViewController.swift
@@ -76,7 +76,7 @@ extension SearchRepositoryTableViewController: UISearchBarDelegate {
     }
 
     private func configureSearchBar() {
-        repositorySearchBar.text = "GitHubのリポジトリを検索できるよー"
+        repositorySearchBar.placeholder = "GitHubのリポジトリを検索できるよー"
         repositorySearchBar.delegate = self
     }
 }


### PR DESCRIPTION
## 概要
- SearchBarの初期値を代入せずに，入力欄が空の時に`GitHubのリポジトリを検索できるよー`とPlaceholderで表記するように
- text入力時に毎回text情報を保持するように

## 関係するISSUE
- Resolve #44

## レビューして欲しいポイント！ 
- 

## スクリーンショット(説明がわかりやすくなるスクリーンショットがあれば添付)
- ![IMG_F124F0340404-1](https://user-images.githubusercontent.com/40351476/193408655-59816733-ea67-47df-9bd6-1c30b819be86.jpeg)
