### PR TITLE
[FIX] リポジトリ詳細画面のタイトルが見切れている問題の修正

### DIFF
--- a/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.storyboard
+++ b/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.storyboard
@@ -24,7 +24,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Repository Fullname" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzY-ow-NLf">
-                                <rect key="frame" x="72.333333333333329" y="503.00000000000006" width="245.33333333333337" height="33.666666666666686"/>
+                                <rect key="frame" x="60" y="503.00000000000006" width="270" height="33.666666666666686"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" systemColor="darkTextColor"/>
                                 <nil key="highlightedColor"/>
@@ -75,8 +75,10 @@
                         <constraints>
                             <constraint firstItem="wzY-ow-NLf" firstAttribute="top" secondItem="r7E-A2-JWo" secondAttribute="bottom" constant="28" id="3VY-tW-jSF"/>
                             <constraint firstItem="Ako-nB-eBV" firstAttribute="centerX" secondItem="wzY-ow-NLf" secondAttribute="centerX" id="8cZ-Mh-7TH"/>
+                            <constraint firstItem="7AQ-AF-gwj" firstAttribute="trailing" secondItem="wzY-ow-NLf" secondAttribute="trailing" constant="60" id="8in-7X-ggd"/>
                             <constraint firstItem="r7E-A2-JWo" firstAttribute="centerY" secondItem="7AQ-AF-gwj" secondAttribute="centerY" multiplier="0.7" id="ChM-Pd-1Ex"/>
                             <constraint firstItem="7AQ-AF-gwj" firstAttribute="trailing" secondItem="r7E-A2-JWo" secondAttribute="trailing" constant="20" id="FyL-kF-eYu"/>
+                            <constraint firstItem="wzY-ow-NLf" firstAttribute="leading" secondItem="7AQ-AF-gwj" secondAttribute="leading" constant="60" id="hhA-uI-DHa"/>
                             <constraint firstItem="Ako-nB-eBV" firstAttribute="width" secondItem="r7E-A2-JWo" secondAttribute="width" id="iYZ-P7-zbK"/>
                             <constraint firstItem="wzY-ow-NLf" firstAttribute="centerX" secondItem="r7E-A2-JWo" secondAttribute="centerX" id="ivc-hm-YxL"/>
                             <constraint firstItem="Ako-nB-eBV" firstAttribute="top" secondItem="wzY-ow-NLf" secondAttribute="bottom" constant="28" id="rgS-fd-wy7"/>

--- a/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.storyboard
+++ b/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.storyboard
@@ -23,7 +23,7 @@
                                     <constraint firstAttribute="width" secondItem="r7E-A2-JWo" secondAttribute="height" multiplier="1:1" id="AZY-zZ-obh"/>
                                 </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Repository Fullname" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzY-ow-NLf">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Repository Fullname" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wzY-ow-NLf">
                                 <rect key="frame" x="60" y="503.00000000000006" width="270" height="33.666666666666686"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                                 <color key="textColor" systemColor="darkTextColor"/>

--- a/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.swift
@@ -21,6 +21,11 @@ class RepositoryDetailViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureLabel()
+        getImage()
+    }
+
+    private func configureLabel() {
         guard let repository = item else { return }
         if let language = repository.language {
             languageLabel.text = "Written in \(language)"
@@ -31,7 +36,6 @@ class RepositoryDetailViewController: UIViewController {
         watchersCountLabel.text = "\(repository.watchersCount) watchers"
         forksCountLabel.text = "\(repository.forksCount) forks"
         openIssueCountLabel.text = "\(repository.openIssuesCount) open issues"
-        getImage()
     }
 
     func getImage() {

--- a/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.swift
@@ -40,6 +40,7 @@ class RepositoryDetailViewController: UIViewController {
 
     func getImage() {
         guard let repository = item else { return }
+        repositoryFullnameLabel.adjustsFontSizeToFitWidth
         repositoryFullnameLabel.text = repository.fullName
         guard let avatarUrl = URL(string: repository.owner.avatarUrl) else { return }
         URLSession.shared.dataTask(with: avatarUrl) { [weak self] (data, _, _) in

--- a/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.swift
+++ b/iOSEngineerCodeCheck/RepositoryDetail/RepositoryDetailViewController.swift
@@ -40,7 +40,7 @@ class RepositoryDetailViewController: UIViewController {
 
     func getImage() {
         guard let repository = item else { return }
-        repositoryFullnameLabel.adjustsFontSizeToFitWidth
+        repositoryFullnameLabel.adjustsFontSizeToFitWidth = true
         repositoryFullnameLabel.text = repository.fullName
         guard let avatarUrl = URL(string: repository.owner.avatarUrl) else { return }
         URLSession.shared.dataTask(with: avatarUrl) { [weak self] (data, _, _) in


### PR DESCRIPTION
## 概要
- リポジトリ詳細画面のタイトルが見切れている問題を修正しました
- タイトルを表記しているUILabelのサイズを動的に変わるようにしました

## 関係するISSUE
- Resolve #47 

## レビューして欲しいポイント！ 
- 

## スクリーンショット(説明がわかりやすくなるスクリーンショットがあれば添付)
- ![Simulator Screen Shot - iPhone 14 Pro - 2022-10-01 at 22 40 29](https://user-images.githubusercontent.com/40351476/193412324-03bc0f1d-042b-4eae-af8d-ae64cffd9b58.png)